### PR TITLE
Move CVE ids from 'aliases' field to 'related'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="errata2osv",
-    version='0.0.2',
+    version='0.0.3',
     author="Nikita Ivanov",
     author_email="nivanov@cloudlinux.com",
     description="Tool to convert Red Hat Errata advisories to Open Source Vulnerability (OSV) database format.",

--- a/src/models/converter.py
+++ b/src/models/converter.py
@@ -17,7 +17,7 @@ def OSVBugFromErrataUpdate(errata_update: ErrataUpdateXMLView, ecosystem=None) -
         logging.warning(f'errata update {errata_update.id} has no title')
     osv.summary = errata_update.title
     osv.affected_packages = _assemble_affected_packages(errata_update, ecosystem)
-    osv.aliases = _aliases_from_description(errata_update)
+    osv.related = _related_from_description(errata_update)
     osv.published_date = errata_update.issued
     osv.modified_date = errata_update.updated
     if errata_update.description is None:
@@ -81,7 +81,7 @@ def _package_full_version(package: ErrataPackageXMLView) -> str:
         return f'{package.version}-{package.release}'
 
 
-def _aliases_from_description(errata_update: ErrataUpdateXMLView) -> List:
+def _related_from_description(errata_update: ErrataUpdateXMLView) -> List:
     """Get aliases from description"""
     description = str(errata_update.title or '') + str(errata_update.description or '')
     return re.findall(r'CVE-\d{4}-\d{4,7}', description)

--- a/src/models/osv_bug.py
+++ b/src/models/osv_bug.py
@@ -12,7 +12,7 @@ class OSVBugJsonView():
         self.summary = bug.summary
         self.affected_packages = sorted(copy.deepcopy(bug.affected_packages),
                                         key=lambda affected: affected.package.name)
-        self.aliases = copy.deepcopy(bug.aliases)
+        self.related = copy.deepcopy(bug.related)
         self.published = bug.published_date
         self.modified = bug.modified_date
         self.details = bug.details
@@ -27,7 +27,7 @@ class OSVBugJsonView():
             'id': self.db_id,
             'summary': self.summary,
             'affected': self.affected_format_list(),
-            'aliases': self.aliases,
+            'related': self.related,
             'published': self.published_format_str(),
             'modified': self.modified_format_str(),
             'details': self.details,


### PR DESCRIPTION
OSV has released some notes specifying more strictly what is considered to be an alias. Therefore, they've requested a change in our current OSV advisories: https://groups.google.com/g/osv-discuss/c/Vg6gka6htkc/m/VC_a_XVaBgAJ
Adjust OSV advisory fields according to the request.