### PR TITLE
Move CVE ids from 'related' to 'upstream'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="errata2osv",
-    version='0.0.3',
+    version='0.0.4',
     author="Nikita Ivanov",
     author_email="nivanov@cloudlinux.com",
     description="Tool to convert Red Hat Errata advisories to Open Source Vulnerability (OSV) database format.",

--- a/src/models/converter.py
+++ b/src/models/converter.py
@@ -17,7 +17,7 @@ def OSVBugFromErrataUpdate(errata_update: ErrataUpdateXMLView, ecosystem=None) -
         logging.warning(f'errata update {errata_update.id} has no title')
     osv.summary = errata_update.title
     osv.affected_packages = _assemble_affected_packages(errata_update, ecosystem)
-    osv.related = _related_from_description(errata_update)
+    osv.upstream = _upstream_from_description(errata_update)
     osv.published_date = errata_update.issued
     osv.modified_date = errata_update.updated
     if errata_update.description is None:
@@ -81,8 +81,8 @@ def _package_full_version(package: ErrataPackageXMLView) -> str:
         return f'{package.version}-{package.release}'
 
 
-def _related_from_description(errata_update: ErrataUpdateXMLView) -> List:
-    """Get aliases from description"""
+def _upstream_from_description(errata_update: ErrataUpdateXMLView) -> List:
+    """Get upstreams from description"""
     description = str(errata_update.title or '') + str(errata_update.description or '')
     return re.findall(r'CVE-\d{4}-\d{4,7}', description)
 

--- a/src/models/osv_bug.py
+++ b/src/models/osv_bug.py
@@ -13,6 +13,7 @@ class OSVBugJsonView():
         self.affected_packages = sorted(copy.deepcopy(bug.affected_packages),
                                         key=lambda affected: affected.package.name)
         self.related = copy.deepcopy(bug.related)
+        self.upstream = copy.deepcopy(bug.upstream)
         self.published = bug.published_date
         self.modified = bug.modified_date
         self.details = bug.details
@@ -27,7 +28,7 @@ class OSVBugJsonView():
             'id': self.db_id,
             'summary': self.summary,
             'affected': self.affected_format_list(),
-            'related': self.related,
+            'upstream': self.upstream,
             'published': self.published_format_str(),
             'modified': self.modified_format_str(),
             'details': self.details,

--- a/src/models/osv_bug.py
+++ b/src/models/osv_bug.py
@@ -12,7 +12,6 @@ class OSVBugJsonView():
         self.summary = bug.summary
         self.affected_packages = sorted(copy.deepcopy(bug.affected_packages),
                                         key=lambda affected: affected.package.name)
-        self.related = copy.deepcopy(bug.related)
         self.upstream = copy.deepcopy(bug.upstream)
         self.published = bug.published_date
         self.modified = bug.modified_date


### PR DESCRIPTION
Hey, I'm Jess from the OSV team. As with discussions in https://github.com/ossf/osv-schema/issues/249, we've just [added support for the upstream field](https://github.com/ossf/osv-schema/pull/312) to better display relations between advisory/vulnerability entries in the OSV schema and database.

This PR moves all of the `related` CVE ids into the `upstream` field instead. 